### PR TITLE
fix(arraymap):  Ignore empty function body

### DIFF
--- a/src/transformers/arraymap.ts
+++ b/src/transformers/arraymap.ts
@@ -27,6 +27,7 @@ export default class ArrayMap extends Transformer<ArrayMapOptions> {
     function visitor(func: Function) {
       if (!Guard.isBlockStatement(func.body)) return
       const body = filterEmptyStatements(func.body.body)
+      if (!body[0]) return
       if (!Guard.isVariableDeclaration(body[0])) return
       const vd = body[0]
       if (vd.declarations.length !== 1) return


### PR DESCRIPTION
If the the BlockStatement is empty after filtering out the empty statements, don't check for a VariableDeclaration at index 0


This shows up in the error log
```
Caught an error while attempting to run AST visitor!
node = {[snip]}
err = TypeError: Cannot read properties of undefined (reading 'type')
```