### PR TITLE
Implement logger option

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -21,6 +21,7 @@ import ArrayMap from './transformers/arraymap'
 import Rename from './transformers/rename'
 import JSCCalculator from './transformers/jsconfuser/calculator'
 import JSCControlFlow from './transformers/jsconfuser/controlflow'
+import { Logger } from './util/logger'
 
 export enum DecoderFunctionType {
   SIMPLE,
@@ -103,17 +104,19 @@ export default class Context {
   removeGarbage: boolean = true
   transformers: InstanceType<typeof Transformer>[]
 
-  enableLog: boolean = true
+  logger: Logger
 
   scopeManager: eslintScope.ScopeManager
   hash: number = 0
 
   constructor(
     ast: Program,
+    logger: Logger,
     transformers: [string, Partial<TransformerOptions>][],
     isModule: boolean,
-    source?: string,
+    source?: string
   ) {
+    this.logger = logger
     this.ast = ast
     this.transformers = this.buildTransformerList(transformers)
 
@@ -125,8 +128,7 @@ export default class Context {
   }
 
   public log(message?: any, ...optionalParams: any[]) {
-    if (!this.enableLog) return
-    console.log(message, ...optionalParams)
+    this.logger('log', message, ...optionalParams)
   }
 
   private buildTransformerList(

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,0 +1,28 @@
+export function defaultLogger(
+  type: 'log' | 'info' | 'warn' | 'error',
+  ...data: any[]
+): void {
+  switch (type) {
+    case 'log':
+      console.log(...data)
+      break
+    case 'info':
+      console.info(...data)
+      break
+    case 'warn':
+      console.warn(...data)
+      break
+    case 'error':
+      console.error(...data)
+      break
+  }
+}
+
+export type Logger = typeof defaultLogger
+
+export function resolveLogger(logger?: Logger | boolean) {
+  if (typeof logger === 'function') return logger
+  else if (logger === false) return () => {}
+  // if it's a weird type or if it's true
+  else return defaultLogger
+}


### PR DESCRIPTION
Based on #26 except with an easier API.

Implementing an option feels annoying and it may be easier for users to determine the type of log based on an argument. However, I do understand why an object may be preferred.

Maybe the type for the logger can be made more explicit like:

```ts
export type Logger = typeof defaultLogger
```

```ts
export type Logger = (
  type: "log" | "info" | "warn" | "error",
  ...data: any[]
) => void
```

And maybe a "name" field can be added so the user can filter through the type of log.

All the above can be easily implemented using this groundwork.