### PR TITLE
fix: cannot find decoder, proxy functions because of some empty statements

### DIFF
--- a/src/transformers/demangle.ts
+++ b/src/transformers/demangle.ts
@@ -1,5 +1,4 @@
 import {
-  Program,
   BlockStatement,
   sp,
   Function,
@@ -17,6 +16,7 @@ import { Transformer, TransformerOptions } from './transformer'
 import { walk } from '../util/walk'
 import * as Guard from '../util/guard'
 import Context from '../context'
+import { filterEmptyStatements } from '../util/helpers'
 
 export interface DemangleOptions extends TransformerOptions {}
 export default class Demangle extends Transformer<DemangleOptions> {
@@ -29,6 +29,7 @@ export default class Demangle extends Transformer<DemangleOptions> {
   demangleProxies(context: Context) {
     function visitor(func: Function) {
       if (!Guard.isBlockStatement(func.body)) return
+      func.body.body = filterEmptyStatements(func.body.body) as Statement[];
       if (func.body.body.length !== 2) return
       let body = func.body.body
 

--- a/src/transformers/stringdecoder.ts
+++ b/src/transformers/stringdecoder.ts
@@ -1,19 +1,13 @@
 import {
-  Program,
-  BlockStatement,
   Node,
   sp,
   VariableDeclaration,
-  ExpressionStatement,
-  ReturnStatement,
-  CallExpression,
   FunctionExpression,
   AssignmentExpression,
   StringLiteral,
   Identifier,
   Statement,
   Literal,
-  UnaryExpression,
   Expression,
   BinaryExpression,
   VariableDeclarator,
@@ -338,7 +332,8 @@ export default class StringDecoder extends Transformer<StringDecoderOptions> {
         const block = node.body
         const fnId = node.id.name
 
-        if (block.body.length > 3 && block.body.length < 1) return
+        block.body = filterEmptyStatements(block.body) as Statement[];
+        if (block.body.length > 3 || block.body.length < 1) return
         if (!block.body[0]) return
         // stringArray declaration
         if (


### PR DESCRIPTION
This PR fixes the following errors when decoder functions contain empty statements:
`err = TypeError: Failed to decode h, no decoder`
`err = Error: Push/shift calculation failed (iter=25>maxLoops=24)`

Input to reproduce the error:
```
;(function (c, d) {
  var h = b,
    e = c()
  while (!![]) {
    try {
      var f =
        (-parseInt(h(0x7a)) / 0x1) * (-parseInt(h(0x78)) / 0x2) +
        (-parseInt(h(0x7e)) / 0x3) * (parseInt(h(0x77)) / 0x4) +
        -parseInt(h(0x7b)) / 0x5 +
        (-parseInt(h(0x7c)) / 0x6) * (-parseInt(h(0x75)) / 0x7) +
        (parseInt(h(0x76)) / 0x8) * (-parseInt(h(0x79)) / 0x9) +
        -parseInt(h(0x80)) / 0xa +
        parseInt(h(0x7f)) / 0xb
      if (f === d) break
      else e["push"](e["shift"]())
    } catch (g) {
      e["push"](e["shift"]())
    }
  }
})(a, 0xa005c)
function hi() {
  var i = b
  console["log"](i(0x7d))
}
hi()
// decoder function
function b(c, d) {
  ;
  ;
  var e = a()
// proxy function
  return (
    (b = function (f, g) {
      f = f - 0x75
      var h = e[f]
      return h
    }),
    b(c, d)
  )
}
function a() {
  ;
  ;
  var j = [
    "1263720pTqteZ",
    "4UVwcYM",
    "18RZHtoU",
    "45NcPTGE",
    "21026baFKTG",
    "5959055zOefdK",
    "76746cPNlrK",
    "Hello\x20World!",
    "3670650mEfMWw",
    "49556463VXYOgg",
    "11662950XTqwOX",
    "182LySSXZ"
  ]
  a = function () {
    return j
  }
  return a()
}
```
